### PR TITLE
doc: fix typo in chapter 2

### DIFF
--- a/part1.md
+++ b/part1.md
@@ -81,7 +81,7 @@ fundamentals are also important to highlight.
 
 The biggest assumption for the design is:
 
-***Greenfield is an economically sustainable, service-oriented
+***Greenfield is a self-sustained, service-oriented
 ecosystem.***
 
 By "self-sustained", it means that the service providers and


### PR DESCRIPTION
## Description

This PR aims to fix a typo of chapter 2.

Changes in detail:

Greenfield is an economically sustainable, service-oriented ecosystem.
=> Greenfield is a self-sustained, service-oriented ecosystem.